### PR TITLE
Update infobox_item_custom.lua

### DIFF
--- a/components/infobox/wikis/deadlock/infobox_item_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_item_custom.lua
@@ -186,6 +186,7 @@ function CustomItem:setLpdbData(args)
 			cost = args.itemcost,
 			category = args.category,
 			removed = tostring(Logic.readBool(args.removed)),
+			tier = args.tier,
 		})
 	}
 	mw.ext.LiquipediaDB.lpdb_datapoint('item_' .. (args.name or self.pagename), lpdbData)


### PR DESCRIPTION
## Summary

Saving args.tier to DB for invoking count on [Portal:Items](https://liquipedia.net/deadlock/Portal:Items)

This gonna be automatically invoked based on "|tier=|type=" in [Template:ItemCostHeader](https://liquipedia.net/deadlock/Template:ItemCostHeader).
Already prepared setup for it inside of the template.

## How did you test this change?
Dev version in [Basic Magazine](https://liquipedia.net/deadlock/Basic_Magazine)
Part of the Invoke in my [Sandbox](https://liquipedia.net/deadlock/User:Sl0thyMan/Sandbox/24)
![image](https://github.com/user-attachments/assets/9acdd2a7-4635-4dfb-9eff-9112bc03472f)


