### PR TITLE
Update infobox_character_custom.lua

### DIFF
--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 
 local Lua = require('Module:Lua')
 
@@ -90,6 +91,8 @@ function CustomHero:addToLpdb(lpdbData, args)
 		damagebullet = args.damagebullet,
 		damagemeleelight = args.damagemeleelight,
 		damagemeleeheavy = args.damagemeleeheavy,
+		playable = tostring(Logic.readBool(args.playable or 'true')),
+		removed = tostring(Logic.readBool(args.removed or 'false')),
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary

Saving args.playable and args.removed to DB for invoking count on [Portal:Heroes](https://liquipedia.net/deadlock/Portal:Heroes).
args.removed is more of the preparation as right now there is no heroes which is completely deleted. If we not gonna scratched heroes from the game before Title Deadlock was announced.

## How did you test this change?

Dev version in [Abrams](https://liquipedia.net/deadlock/Abrams)
Tried showing DB without any args. Which default to 
playable = true
removed = false

and even tried setting up args.removed/playable manually to specific state.
With args.
![image](https://github.com/user-attachments/assets/7ac74bb9-983c-4500-8102-244d80ac2639)
Without args.
![image](https://github.com/user-attachments/assets/3d21d4d7-0a27-4e73-9b7b-e0909247e81a)

